### PR TITLE
fix(docs): improve language tab visibility and active state

### DIFF
--- a/templates/core/developer_guide.html
+++ b/templates/core/developer_guide.html
@@ -136,17 +136,20 @@
                     <div class="border-b border-white/5 bg-slate-900/50">
                         <ul class="flex flex-wrap -mb-px text-sm font-medium text-center" id="defaultTab" data-tabs-toggle="#defaultTabContent" role="tablist">
                             <li class="me-2" role="presentation">
-                                <button class="inline-block p-4 border-b-2 rounded-t-lg hover:text-indigo-300 hover:border-indigo-300/30 text-indigo-400 border-indigo-400 bg-white/5" id="curl-tab" data-tabs-target="#curl" type="button" role="tab" aria-controls="curl" aria-selected="true">
+                                <button class="inline-block p-4 border-b-2 rounded-t-lg transition-all aria-selected:text-white aria-selected:border-indigo-500 aria-selected:bg-indigo-500/10 text-slate-500 border-transparent hover:text-slate-300 hover:border-slate-700"
+                                        id="curl-tab" data-tabs-target="#curl" type="button" role="tab" aria-controls="curl" aria-selected="true">
                                     cURL
                                 </button>
                             </li>
                             <li class="me-2" role="presentation">
-                                <button class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-indigo-300 hover:border-indigo-300/30 text-slate-400" id="python-tab" data-tabs-target="#python" type="button" role="tab" aria-controls="python" aria-selected="false">
+                                <button class="inline-block p-4 border-b-2 rounded-t-lg transition-all aria-selected:text-white aria-selected:border-indigo-500 aria-selected:bg-indigo-500/10 text-slate-500 border-transparent hover:text-slate-300 hover:border-slate-700"
+                                        id="python-tab" data-tabs-target="#python" type="button" role="tab" aria-controls="python" aria-selected="false">
                                     Python
                                 </button>
                             </li>
                             <li class="me-2" role="presentation">
-                                <button class="inline-block p-4 border-b-2 border-transparent rounded-t-lg hover:text-indigo-300 hover:border-indigo-300/30 text-slate-400" id="js-tab" data-tabs-target="#js" type="button" role="tab" aria-controls="js" aria-selected="false">
+                                <button class="inline-block p-4 border-b-2 rounded-t-lg transition-all aria-selected:text-white aria-selected:border-indigo-500 aria-selected:bg-indigo-500/10 text-slate-500 border-transparent hover:text-slate-300 hover:border-slate-700"
+                                        id="js-tab" data-tabs-target="#js" type="button" role="tab" aria-controls="js" aria-selected="false">
                                     JavaScript
                                 </button>
                             </li>


### PR DESCRIPTION
Improved the contrast of the documentation tabs so users know which language (cURL/Python/JS) is currently selected.